### PR TITLE
Removed `ifequal`, which was removed in Django 4

### DIFF
--- a/django_starfield/templates/django_starfield/stars.html
+++ b/django_starfield/templates/django_starfield/stars.html
@@ -2,7 +2,7 @@
 <div class="django-starfield" id="django-starfield-{{ widget.name }}">
  {% for i in stars %}
   <input type="radio" name="{{ widget.name }}" id="{{ widget.name }}-{{ forloop.counter0 }}"
-         value="{{ i }}" {% ifequal widget.value i|stringformat:'i' %}checked="checked"{% endifequal %} />
+          value="{{ i }}" {% if widget.value == i|stringformat:'i' %}checked="checked"{% endif %} />
   <label for="{{ widget.name }}-{{ forloop.counter0 }}"><span>{{ i }}</span></label>
  {% endfor %}
 </div>


### PR DESCRIPTION
Replicates the original [PR #2](https://edugit.org/nik/django-starfield/-/merge_requests/2) that has not been merged in the source repo: https://edugit.org/nik/django-starfield

fixes issue: [Starfield broken in Django 4 due to ifequal being removed](https://edugit.org/nik/django-starfield/-/issues/6) in origin repo